### PR TITLE
switch configure-aws-credentials action to version running on node16

### DIFF
--- a/.github/workflows/migration.yaml
+++ b/.github/workflows/migration.yaml
@@ -66,7 +66,7 @@ jobs:
           known_hosts: unnecessary
           if_key_exists: fail
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/${{ inputs.GITHUB_ROLE }}
           role-session-name: ${{ inputs.GITHUB_ROLE }}-oidc


### PR DESCRIPTION
## What/Why/How?

Switching `aws-actions/configure-aws-credentials` action version from `master` to `v1-node16` to get rid of watning during action being run (`node12` being deprecated) and action failing from Jun 1 2023 

## Reference

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

## Testing

## Screenshots (optional)
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/4015321/222692320-43ae5d57-50f3-49e7-85ac-158e094ee819.png">


