### PR TITLE
SESC-6838: Improve deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,10 +32,15 @@ on:
         required: false
         type: string
         default: ''
+      TIMEOUT:
+        required: false
+        type: number
+        default: 30
 
 jobs:
   deploy:
     runs-on: ubuntu-20.04
+    timeout-minutes: ${{ inputs.TIMEOUT }}
     steps:
       - name: Default Checkout
         uses: actions/checkout@v3
@@ -54,7 +59,7 @@ jobs:
         if: inputs.WAIT_UNTIL_STABLE
         run: |
           echo "[INFO] Waiting for ECS service to reach stable state."
-          local status=$?
+          status=0
           for i in {1..3}; do
             aws ecs wait services-stable --cluster ${{ inputs.AWS_CLUSTER_NAME }} --service ${{ inputs.AWS_SERVICE_NAME }} && break || status=$? && sleep 0.1
           done

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,7 @@ name: Stage Deploy
 permissions:
   id-token: write
   contents: read
+  deployments: write
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,10 @@ on:
       GITHUB_ROLE:
         required: true
         type: string
+      ROLE_SESSION_NAME:
+        required: false
+        type: string
+        default: normalizer-testint-oidc
       AWS_REGION:
         required: true
         type: string
@@ -20,6 +24,14 @@ on:
       AWS_SERVICE_NAME:
         required: true
         type: string
+      WAIT_UNTIL_STABLE:
+        required: false
+        type: boolean
+        default: false
+      DEPLOYMENT_ID:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   deploy:
@@ -29,11 +41,41 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/${{ inputs.GITHUB_ROLE }}
-          role-session-name: normalizer-testint-oidc
+          role-session-name: ${{ inputs.ROLE_SESSION_NAME }} 
           aws-region: ${{ inputs.AWS_REGION }}
 
       - name: AWS ECS - Deploy
         run: aws ecs update-service --force-new-deployment --cluster ${{ inputs.AWS_CLUSTER_NAME }} --service ${{ inputs.AWS_SERVICE_NAME }}
+
+      - name: AWS ECS - Await Stable State
+        if: inputs.WAIT_UNTIL_STABLE
+        run: |
+          echo "[INFO] Waiting for ECS service to reach stable state."
+          local status=$?
+          for i in {1..3}; do
+            aws ecs wait services-stable --cluster ${{ inputs.AWS_CLUSTER_NAME }} --service ${{ inputs.AWS_SERVICE_NAME }} && break || status=$? && sleep 0.1
+          done
+          if [ $status -ne 0 ]; then
+            echo "[ERROR] ECS service didn't reach stable state after 3 retries."
+            exit $status
+          fi
+          echo "[INFO] ECS service reached stable state."
+
+      - name: Update deployment status (success)
+        if: success() && inputs.DEPLOYMENT_ID != ''
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          state: success
+          deployment-id: ${{ inputs.DEPLOYMENT_ID }}
+
+      - name: Update deployment status (failure)
+        if: failure() && inputs.DEPLOYMENT_ID != ''
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          state: failure
+          deployment-id: ${{ inputs.DEPLOYMENT_ID }}


### PR DESCRIPTION
1. Allow letting the workflow wait for the deployment to reach stable status
2. Allow specifying deployment id, which is marked as either failed or completed, all depending on the outcome of this workflow
3. Allow specifying a timeout for the workflow (default to 30 minutes)