### PR TITLE
Using non-deprecated way to set env variable

### DIFF
--- a/.github/workflows/deploy-lambda.yaml
+++ b/.github/workflows/deploy-lambda.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Change lambda description if deploying dev environment
         if: inputs.ENVIRONMENT_NAME == 'dev'
         run:
-          echo "::set-env name=LAMBDA_DESCRIPTION::${GITHUB_REF#refs/heads/}.${GITHUB_SHA::7}"
+          echo "LAMBDA_DESCRIPTION=${GITHUB_REF#refs/heads/}.${GITHUB_SHA::7}" >> "$GITHUB_ENV"
       - name: Create GitHub deployment
         uses: chrnorm/deployment-action@v2
         id: deployment


### PR DESCRIPTION
## What/Why/How?
The set-env command for gh actions has been deprecated and we can not use it in our workflows. I have updated setting env variables to the update way referenced here:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
## Reference
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

