### PR TITLE
Fix for code coverage artifact download

### DIFF
--- a/.github/workflows/add-jacoco-coverage-report.yaml
+++ b/.github/workflows/add-jacoco-coverage-report.yaml
@@ -26,17 +26,18 @@ jobs:
         id: download
         with:
           name: ${{ inputs.BUILD_DIRECTORY_NAME }}-jacoco
+          path: ${{ env.JACOCO_DIRECTORY }}
       - name: Add source coverage to PR
         uses: madrapps/jacoco-report@v1.6.1
         with:
-          paths: ${{steps.download.outputs.download-path}}/jacocoTestReport.xml
+          paths: ${{ env.JACOCO_DIRECTORY }}/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "${{ inputs.BUILD_DIRECTORY_NAME }}: Test Coverage Report"
           update-comment: true
       - name: Generate JaCoCo Badge
         uses: cicirello/jacoco-badge-generator@v2
         with:
-          jacoco-csv-file: ${{steps.download.outputs.download-path}}/jacocoTestReport.csv
+          jacoco-csv-file: ${{ env.JACOCO_DIRECTORY }}/jacocoTestReport.csv
           badges-directory: ${{ inputs.BADGES_DIRECTORY }}
           generate-coverage-badge: true
           coverage-badge-filename: jacoco-coverage.svg

--- a/.github/workflows/add-jacoco-coverage-report.yaml
+++ b/.github/workflows/add-jacoco-coverage-report.yaml
@@ -20,6 +20,7 @@ jobs:
     name: Generate and add code coverage to PR
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Download jacoco artifacts
         uses: actions/download-artifact@v3
         id: download

--- a/.github/workflows/add-jacoco-coverage-report.yaml
+++ b/.github/workflows/add-jacoco-coverage-report.yaml
@@ -20,17 +20,22 @@ jobs:
     name: Generate and add code coverage to PR
     runs-on: ubuntu-latest
     steps:
+      - name: Download jacoco artifacts
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          name: ${{ inputs.BUILD_DIRECTORY_NAME }}-jacoco
       - name: Add source coverage to PR
         uses: madrapps/jacoco-report@v1.6.1
         with:
-          paths: ${{ github.workspace }}/${{ inputs.BUILD_DIRECTORY_NAME }}/build/reports/jacoco/test/jacocoTestReport.xml
+          paths: ${{steps.download.outputs.download-path}}/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "${{ inputs.BUILD_DIRECTORY_NAME }}: Test Coverage Report"
           update-comment: true
       - name: Generate JaCoCo Badge
         uses: cicirello/jacoco-badge-generator@v2
         with:
-          jacoco-csv-file: ${{ inputs.BUILD_DIRECTORY_NAME }}/build/reports/jacoco/test/jacocoTestReport.csv
+          jacoco-csv-file: ${{steps.download.outputs.download-path}}/jacocoTestReport.csv
           badges-directory: ${{ inputs.BADGES_DIRECTORY }}
           generate-coverage-badge: true
           coverage-badge-filename: jacoco-coverage.svg

--- a/.github/workflows/add-jacoco-coverage-report.yaml
+++ b/.github/workflows/add-jacoco-coverage-report.yaml
@@ -1,5 +1,8 @@
 name: Add Jacoco code coverage to Pull Request
 
+env:
+  JACOCO_DIRECTORY: ${{ inputs.BUILD_DIRECTORY_NAME }}/build/reports/jacoco/test
+
 on:
   workflow_call:
     inputs:
@@ -20,10 +23,13 @@ jobs:
     name: Generate and add code coverage to PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Download jacoco artifacts
-        uses: actions/download-artifact@v3
         id: download
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.BUILD_DIRECTORY_NAME }}-jacoco
           path: ${{ env.JACOCO_DIRECTORY }}

--- a/.github/workflows/build-jvm-lambda.yaml
+++ b/.github/workflows/build-jvm-lambda.yaml
@@ -43,3 +43,10 @@ jobs:
         with:
           name: ${{ inputs.BUILD_DIRECTORY_NAME }}-build
           path: ${{ inputs.BUILD_DIRECTORY_NAME }}/build/libs/${{ inputs.BUILD_DIRECTORY_NAME }}${{ inputs.JAR_FILE_EXTENSION}}
+      - name: Upload jacoco files
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.BUILD_DIRECTORY_NAME }}-jacoco
+          path: |
+            ${{ inputs.BUILD_DIRECTORY_NAME }}/build/reports/jacoco/test/jacocoTestReport.xml
+            ${{ inputs.BUILD_DIRECTORY_NAME }}/build/reports/jacoco/test/jacocoTestReport.csv

--- a/.github/workflows/build-jvm-lambda.yaml
+++ b/.github/workflows/build-jvm-lambda.yaml
@@ -1,5 +1,8 @@
 name: Build JVM Lambda
 
+env:
+  JACOCO_DIRECTORY: ${{ inputs.BUILD_DIRECTORY_NAME }}/build/reports/jacoco/test
+
 on:
   workflow_call:
     inputs:
@@ -43,10 +46,10 @@ jobs:
         with:
           name: ${{ inputs.BUILD_DIRECTORY_NAME }}-build
           path: ${{ inputs.BUILD_DIRECTORY_NAME }}/build/libs/${{ inputs.BUILD_DIRECTORY_NAME }}${{ inputs.JAR_FILE_EXTENSION}}
-      - name: Upload jacoco files
+      - name: Upload jacoco artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.BUILD_DIRECTORY_NAME }}-jacoco
           path: |
-            ${{ inputs.BUILD_DIRECTORY_NAME }}/build/reports/jacoco/test/jacocoTestReport.xml
-            ${{ inputs.BUILD_DIRECTORY_NAME }}/build/reports/jacoco/test/jacocoTestReport.csv
+            ${{ env.JACOCO_DIRECTORY }}/jacocoTestReport.xml
+            ${{ env.JACOCO_DIRECTORY }}/jacocoTestReport.csv


### PR DESCRIPTION
## What/Why/How?

- Fixed issue with add-jacoco-coverage-report action where jacoco artifacts weren't being downloaded properly
- Fixed issue where the action was failing while using the endbug/add-and-commit action by directly checking out the branch the PR is coming from as described here:
https://github.com/EndBug/add-and-commit#working-with-prs



