### PR TITLE
AWS CLI input bugfix for deploy-lambda

### DIFF
--- a/.github/workflows/deploy-lambda.yaml
+++ b/.github/workflows/deploy-lambda.yaml
@@ -62,23 +62,23 @@ jobs:
           aws-region: ${{ inputs.AWS_REGION }}
       - name: Update source function code, push new version, and update alias
         run: |
-          aws lambda update-function-code --function-name ${{ inputs.LAMBDA_NAME }} --zip-file fileb://./${{ inputs.BUILD_DIRECTORY_NAME }}/build/libs/${{ inputs.BUILD_DIRECTORY_NAME }}${{ inputs.JAR_FILE_EXTENSION }}
+          aws lambda update-function-code --function-name "${{ inputs.LAMBDA_NAME }}" --zip-file fileb://./${{ inputs.BUILD_DIRECTORY_NAME }}/build/libs/${{ inputs.BUILD_DIRECTORY_NAME }}${{ inputs.JAR_FILE_EXTENSION }}
           sleep 5
-          aws lambda publish-version --function-name ${{ inputs.LAMBDA_NAME }} --description ${{ env.LAMBDA_DESCRIPTION }}
+          aws lambda publish-version --function-name "${{ inputs.LAMBDA_NAME }}" --description "${{ env.LAMBDA_DESCRIPTION }}"
           latestVersion=$( aws lambda list-versions-by-function --function-name ${{ inputs.LAMBDA_NAME }} --no-paginate --query "max_by(Versions, &to_number(to_number(Version) || '0'))" )
           latestVersionNumber=$( echo $latestVersion | grep -o '"Version": "[^"]*' | grep -o '[^"]*$' )
           echo "The latest version number is $latestVersionNumber"
-          aws lambda update-alias --function-name ${{ inputs.LAMBDA_NAME }} --name live --function-version $latestVersionNumber --routing-config AdditionalVersionWeights={}
+          aws lambda update-alias --function-name "${{ inputs.LAMBDA_NAME }}" --name live --function-version $latestVersionNumber --routing-config AdditionalVersionWeights={}
       - name: Update deployment status (success)
         if: success()
-        uses: chrnorm/deployment-action@v2
+        uses: chrnorm/deployment-status@v2
         with:
           token: ${{ github.token }}
           state: success
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
       - name: Update deployment status (failure)
         if: failure()
-        uses: chrnorm/deployment-action@v2
+        uses: chrnorm/deployment-status@v2
         with:
           token: ${{ github.token }}
           state: failure


### PR DESCRIPTION
## What/Why/How?

- During a prod deploy using this workflow, the AWS publish version step failed with a 252 exit code. This was because the generated lambda release description input contained a number and a space which broke the CLI command and failed the action. This PR will fix this by always stringifying the CLI inputs that should be strings. 

- Changing the update deployment status to use the proper chrnorm workflow.

## Reference
AWS CLI breaking input:
--description Release v1.1.9
updated stringifyed input:
--description "Release v1.1.10"

Failing job:
https://github.com/bettermile/bm-lambda-datacollector/actions/runs/6735474740/job/18308946331
AWS CLI exit code explanation:
https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-returncodes.html
## Testing
Job that works with the stringifyed input:
https://github.com/bettermile/bm-lambda-datacollector/actions/runs/6736862937/job/18313263704
