### PR TITLE
Fix redocly cli version

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Default checkout
         uses: actions/checkout@v3
       - name: Install @redocly/cli
-        run: npm i -g @redocly/cli@latest
+        run: npm i -g @redocly/cli@1.7.0
       - name: Documentation push
         run: |
           cd ${{ inputs.OPENAPI_DEFINITION_PATH || './openapi' }}


### PR DESCRIPTION
## What/Why/How?
Redocly published a version 1.8 some days ago and since then the `push` function fails for multiple teams at Bettermile. This PR is a quickfix and fixes the redocli cli version to version `1.7.0`-

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
