### PR TITLE
SESC-9438: Extend Pulumi Build & Preview workflows

### DIFF
--- a/.github/workflows/pulumi-build.yaml
+++ b/.github/workflows/pulumi-build.yaml
@@ -11,6 +11,11 @@ on:
         required: false
         type: string
         default: './'
+    secrets:
+      PKG_ACTOR:
+        required: false
+      PKG_TOKEN:
+        required: false
 
 jobs:
   build:
@@ -31,5 +36,10 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Build
+      - name: Build With Credentials
+        if: ${{ secrets.PKG_ACTOR != '' }}
+        run: PKG_ACTOR=${{ secrets.PKG_ACTOR }} PKG_TOKEN=${{ secrets.PKG_TOKEN }} ./gradlew clean build
+
+      - name: Build Without Credentials
+        if: ${{ secrets.PKG_ACTOR == '' }}
         run: ./gradlew clean build

--- a/.github/workflows/pulumi-build.yaml
+++ b/.github/workflows/pulumi-build.yaml
@@ -23,6 +23,9 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.WORK_DIR }}
+    env:
+      PKG_ACTOR: ${{ secrets.PKG_ACTOR }}
+      PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -36,10 +39,5 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Build With Credentials
-        if: ${{ secrets.PKG_ACTOR != '' }}
-        run: PKG_ACTOR=${{ secrets.PKG_ACTOR }} PKG_TOKEN=${{ secrets.PKG_TOKEN }} ./gradlew clean build
-
-      - name: Build Without Credentials
-        if: ${{ secrets.PKG_ACTOR == '' }}
+      - name: Build
         run: ./gradlew clean build

--- a/.github/workflows/pulumi-preview.yaml
+++ b/.github/workflows/pulumi-preview.yaml
@@ -20,6 +20,18 @@ on:
       AWS_REGION:
         required: true
         type: string
+      PULUMI_STATE_AWS_ACCOUNT_ID:
+        required: false
+        type: string
+      PULUMI_STATE_AWS_ROLE_NAME:
+        required: false
+        type: string
+      PULUMI_STATE_AWS_PROFILE:
+        required: false
+        type: string
+      PULUMI_STATE_AWS_REGION:
+        required: false
+        type: string
       PULUMI_STACK:
         required: true
         type: string
@@ -38,14 +50,30 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Configure AWS role
+      - name: Configure Pulumi State AWS role
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        if: ${{ inputs.PULUMI_STATE_AWS_ACCOUNT_ID != '' }}
+        with:
+          role-to-assume: arn:aws:iam::${{ inputs.PULUMI_STATE_AWS_ACCOUNT_ID }}:role/${{ inputs.PULUMI_STATE_AWS_ROLE_NAME }}
+          role-session-name: ${{ github.event.repository.name}}-${{ github.run_id }}
+          aws-region: ${{ inputs.PULUMI_STATE_AWS_REGION }}
+
+      - name: Setup Pulumi State Profile
+        if: ${{ inputs.PULUMI_STATE_AWS_ACCOUNT_ID != '' }}
+        run: |
+          aws configure set region ${{ env.AWS_REGION }} --profile ${{ inputs.PULUMI_STATE_AWS_PROFILE }}
+          aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }} --profile ${{ inputs.PULUMI_STATE_AWS_PROFILE }}
+          aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }} --profile ${{ inputs.PULUMI_STATE_AWS_PROFILE }}
+          aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }} --profile ${{ inputs.PULUMI_STATE_AWS_PROFILE }}
+
+      - name: Configure Main AWS role
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/${{ inputs.AWS_ROLE_NAME }}
           role-session-name: ${{ github.event.repository.name}}-${{ github.run_id }}
           aws-region: ${{ inputs.AWS_REGION }}
 
-      - name: Setup Profile
+      - name: Setup Main Profile
         run: |
           aws configure set region ${{ env.AWS_REGION }} --profile ${{ inputs.AWS_PROFILE }}
           aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }} --profile ${{ inputs.AWS_PROFILE }}

--- a/.github/workflows/pulumi-preview.yaml
+++ b/.github/workflows/pulumi-preview.yaml
@@ -42,10 +42,18 @@ on:
         required: false
         type: string
         default: './'
+    secrets:
+      PKG_ACTOR:
+        required: false
+      PKG_TOKEN:
+        required: false
 
 jobs:
   build:
     runs-on: ubuntu-22.04
+    env:
+      PKG_ACTOR: ${{ secrets.PKG_ACTOR }}
+      PKG_TOKEN: ${{ secrets.PKG_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pulumi-preview.yaml
+++ b/.github/workflows/pulumi-preview.yaml
@@ -88,6 +88,12 @@ jobs:
           aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }} --profile ${{ inputs.AWS_PROFILE }}
           aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }} --profile ${{ inputs.AWS_PROFILE }}
 
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+
       - uses: pulumi/actions@v5
         with:
           command: preview


### PR DESCRIPTION
* `pulumi-build` needs to support passing in GitHub packages secrets
* `pulumi-preview` needs to support using different AWS credentials for working with Pulumi state and applying AWS infra changes