### PR TITLE
Adding better way to get the latest version number for lambdas

### DIFF
--- a/.github/workflows/deploy-lambda.yaml
+++ b/.github/workflows/deploy-lambda.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           aws lambda update-function-code --function-name "${{ inputs.LAMBDA_NAME }}" --zip-file fileb://./${{ inputs.BUILD_DIRECTORY_NAME }}/build/libs/${{ inputs.BUILD_DIRECTORY_NAME }}${{ inputs.JAR_FILE_EXTENSION }}
           sleep 5
-          latestVersionNumber=$( aws lambda publish-version --function-name ${{ inputs.LAMBDA_NAME }} --description "${{ env.LAMBDA_DESCRIPTION }}" --query "Version" --output text )
+          latestVersionNumber=$( aws lambda publish-version --function-name "${{ inputs.LAMBDA_NAME }}" --description "${{ env.LAMBDA_DESCRIPTION }}" --query "Version" --output text )
           echo "The latest version number is $latestVersionNumber"
           aws lambda update-alias --function-name "${{ inputs.LAMBDA_NAME }}" --name live --function-version $latestVersionNumber --routing-config AdditionalVersionWeights={}
 

--- a/.github/workflows/deploy-lambda.yaml
+++ b/.github/workflows/deploy-lambda.yaml
@@ -69,9 +69,7 @@ jobs:
         run: |
           aws lambda update-function-code --function-name "${{ inputs.LAMBDA_NAME }}" --zip-file fileb://./${{ inputs.BUILD_DIRECTORY_NAME }}/build/libs/${{ inputs.BUILD_DIRECTORY_NAME }}${{ inputs.JAR_FILE_EXTENSION }}
           sleep 5
-          aws lambda publish-version --function-name "${{ inputs.LAMBDA_NAME }}" --description "${{ env.LAMBDA_DESCRIPTION }}"
-          latestVersion=$( aws lambda list-versions-by-function --function-name ${{ inputs.LAMBDA_NAME }} --no-paginate --query "max_by(Versions, &to_number(to_number(Version) || '0'))" )
-          latestVersionNumber=$( echo $latestVersion | grep -o '"Version": "[^"]*' | grep -o '[^"]*$' )
+          latestVersionNumber=$( aws lambda publish-version --function-name ${{ inputs.LAMBDA_NAME }} --description env.LAMBDA_DESCRIPTION --query "Version" --output text )
           echo "The latest version number is $latestVersionNumber"
           aws lambda update-alias --function-name "${{ inputs.LAMBDA_NAME }}" --name live --function-version $latestVersionNumber --routing-config AdditionalVersionWeights={}
 

--- a/.github/workflows/deploy-lambda.yaml
+++ b/.github/workflows/deploy-lambda.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           aws lambda update-function-code --function-name "${{ inputs.LAMBDA_NAME }}" --zip-file fileb://./${{ inputs.BUILD_DIRECTORY_NAME }}/build/libs/${{ inputs.BUILD_DIRECTORY_NAME }}${{ inputs.JAR_FILE_EXTENSION }}
           sleep 5
-          latestVersionNumber=$( aws lambda publish-version --function-name ${{ inputs.LAMBDA_NAME }} --description env.LAMBDA_DESCRIPTION --query "Version" --output text )
+          latestVersionNumber=$( aws lambda publish-version --function-name ${{ inputs.LAMBDA_NAME }} --description "${{ env.LAMBDA_DESCRIPTION }}" --query "Version" --output text )
           echo "The latest version number is $latestVersionNumber"
           aws lambda update-alias --function-name "${{ inputs.LAMBDA_NAME }}" --name live --function-version $latestVersionNumber --routing-config AdditionalVersionWeights={}
 


### PR DESCRIPTION
## What/Why/How?
The previous way to get the latest version number for lambdas would run into issues when around 100 versions of the lambda exists. This change fixes this. Thanks @criedel for helping find a good solution for this

## Reference
You can see this change working here:
https://github.com/bettermile/bm-lambda-qsdashboard-api/actions/runs/10387092559/workflow#L68

