### PR TITLE
Wait for lambda's last update status to become successful

### DIFF
--- a/.github/workflows/deploy-lambda.yaml
+++ b/.github/workflows/deploy-lambda.yaml
@@ -68,7 +68,10 @@ jobs:
       - name: Update source function code, push new version, and update alias
         run: |
           aws lambda update-function-code --function-name "${{ inputs.LAMBDA_NAME }}" --zip-file fileb://./${{ inputs.BUILD_DIRECTORY_NAME }}/build/libs/${{ inputs.BUILD_DIRECTORY_NAME }}${{ inputs.JAR_FILE_EXTENSION }}
-          sleep 5
+          while [[ $(aws lambda get-function --function-name ${{ inputs.LAMBDA_NAME }} --query "Configuration.LastUpdateStatus" --output text) != "Successful" ]]; do
+            echo "Waiting for the function to become active..."
+            sleep 1
+          done
           latestVersionNumber=$( aws lambda publish-version --function-name "${{ inputs.LAMBDA_NAME }}" --description "${{ env.LAMBDA_DESCRIPTION }}" --query "Version" --output text )
           echo "The latest version number is $latestVersionNumber"
           aws lambda update-alias --function-name "${{ inputs.LAMBDA_NAME }}" --name live --function-version $latestVersionNumber --routing-config AdditionalVersionWeights={}


### PR DESCRIPTION
## What/Why/How?

5 seconds is not always enough and we can't really predict how long it's going to take for the function to become active.

## Reference

Here's an example of how it fails when the function takes longer than 5 seconds to update: https://github.com/bettermile/bm-lambda-tokenauthorizer/actions/runs/10702727051/job/29671778574

```
An error occurred (ResourceConflictException) when calling the PublishVersion operation: The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:eu-central-1:591625405895:function:lta-prod-tokenauthorizer
```

Here's an example of how it will look like after this change: https://github.com/bettermile/bm-lambda-qsdashboard-api/actions/runs/10718604018/job/29720890773