### PR TITLE
Bump madrapps/jacoco-report to 1.7.0

### DIFF
--- a/.github/workflows/add-jacoco-coverage-report.yaml
+++ b/.github/workflows/add-jacoco-coverage-report.yaml
@@ -37,7 +37,7 @@ jobs:
           path: ${{ env.JACOCO_DIRECTORY }}
 
       - name: Add source coverage to PR
-        uses: madrapps/jacoco-report@v1.6
+        uses: madrapps/jacoco-report@v1.7.0
         with:
           paths: ${{ env.JACOCO_DIRECTORY }}/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report-coverage.yaml
+++ b/.github/workflows/report-coverage.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Add coverage to PR
         if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && !inputs.AGGREGATED_JACOCO_REPORT
-        uses: madrapps/jacoco-report@v1.6.1
+        uses: madrapps/jacoco-report@v1.7.0
         with:
           paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Add coverage to PR from aggregated report
         if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && inputs.AGGREGATED_JACOCO_REPORT
-        uses: madrapps/jacoco-report@v1.6.1
+        uses: madrapps/jacoco-report@v1.7.0
         with:
           paths: ${{ github.workspace }}/build/reports/jacoco/jacocoAggregatedReport/jacocoAggregatedReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Add coverage to PR
         if: github.event_name == 'pull_request'
-        uses: madrapps/jacoco-report@v1.6.1
+        uses: madrapps/jacoco-report@v1.7.0
         with:
           paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Commit 3f013bdceccf9f36181ca3d788b69c3294ec60bf has downgraded it in `add-jacoco-coverage-report.yaml` from v1.6.1 to v1.6, which has a bug.

Since not all workflows use the same version, renovate does not update all of them: 03507ac2f0495c231ee7202e114c018e1d129fec